### PR TITLE
Use makedirs instead of mkdir

### DIFF
--- a/sams-post-receiver.py
+++ b/sams-post-receiver.py
@@ -36,11 +36,11 @@ class Receiver(MethodView):
 
             if not os.path.isdir(base_path):
                 try:
-                    os.mkdir(base_path)
+                    os.makedirs(base_path)
                 except Exception as err:
                     # Handle possible raise from other process
                     if not os.path.isdir(base_path):
-                        assert False, "Failed to mkdir '%s' " % base_path
+                        assert False, "Failed to makedirs '%s' " % base_path
 
         tfilename = ".%s" % filename
         try:

--- a/sams/loader/File.py
+++ b/sams/loader/File.py
@@ -55,11 +55,11 @@ class Loader(sams.base.Loader):
         out_path = os.path.join(self.error_path,self.current_file['path'])
         if not os.path.isdir(out_path):
             try:
-                os.mkdir(out_path)
+                os.makedirs(out_path)
             except Exception as err:
                 # Handle possible raise from other process
                 if not os.path.isdir(out_path):
-                    assert False, "Failed to mkdir '%s' " % out_path
+                    assert False, "Failed to makedirs '%s' " % out_path
 
         # Rename file to error directory
         os.rename(os.path.join(self.in_path,self.current_file['path'],self.current_file['file']),
@@ -75,11 +75,11 @@ class Loader(sams.base.Loader):
         out_path = os.path.join(self.archive_path,self.current_file['path'])
         if not os.path.isdir(out_path):
             try:
-                os.mkdir(out_path)
+                os.makedirs(out_path)
             except Exception as err:
                 # Handle possible raise from other process
                 if not os.path.isdir(out_path):
-                    assert False, "Failed to mkdir '%s' " % out_path
+                    assert False, "Failed to makedirs '%s' " % out_path
 
         # Rename file to archive directory
         os.rename(os.path.join(self.in_path,self.current_file['path'],self.current_file['file']),

--- a/sams/output/File.py
+++ b/sams/output/File.py
@@ -63,11 +63,11 @@ class Output(sams.base.Output):
 
             if not os.path.isdir(base_path):
                 try:
-                    os.mkdir(base_path)
+                    os.makedirs(base_path)
                 except Exception as err:
                     # Handle possible raise from other process
                     if not os.path.isdir(base_path):
-                        assert False, "Failed to mkdir '%s' " % base_path
+                        assert False, "Failed to makedirs '%s' " % base_path
 
         try:
             with open(os.path.join(base_path,tfilename),"w") as file:


### PR DESCRIPTION
Do not rely on all components in the directory tree being
precreated.

Fixes #3.