### PR TITLE
bugfix exception handling in software updater

### DIFF
--- a/sams-software-updater.py
+++ b/sams-software-updater.py
@@ -103,7 +103,8 @@ class Main:
             try:
                 self.backend.update(self.updater)
             except Exception as e:
-                logger.exception("Failed to update",e)
+                logger.error("Failed to update")
+                logger.exception(e)
 
 if __name__ == "__main__":
     Main().start()


### PR DESCRIPTION
This is a small bug fix in the exception handling of `sams-software-updater.py` without it any exception will only give the not so helpful error message.

```
Traceback (most recent call last):
File "/usr/lib64/python2.7/logging/__init__.py", line 851, in emit
msg = self.format(record)
File "/usr/lib64/python2.7/logging/__init__.py", line 724, in format
return fmt.format(record)
File "/usr/lib64/python2.7/logging/__init__.py", line 464, in format
record.message = record.getMessage()
File "/usr/lib64/python2.7/logging/__init__.py", line 328, in getMessage
msg = msg % self.args
TypeError: not all arguments converted during string formatting
Logged from file sams-software-updater.py, line 103
```

This is triggered by passing multiple arguments to the methods of the logger, for details see http://notemagnet.blogspot.com/2009/07/python-logging-typeerror-messages.html .