### PR TITLE
bugfix extractor crashes for core seconds equal to None

### DIFF
--- a/sams/backend/SoftwareAccounting.py
+++ b/sams/backend/SoftwareAccounting.py
@@ -163,7 +163,7 @@ class Backend(sams.base.Backend):
             print("\tLocal Version: %s" % software[3])
             print("\tUser Provided: %s" % software[4])
             print("\tIgnore       : %s" % software[5])
-            print("\tCore Hours   : %.1f" % (software[7] / 3600.0))
+            print("\tCore Hours   : %.1f" % (software[7] / 3600.0 if software[7] is not None else 0.))
             print("\tJob Count    : %d" % software[8])
         else:
             print("\tSoftware is not determined")


### PR DESCRIPTION
Can not assume that the core second count (in `software[7]`) is a float when converting to core hours. 

Without this the extractor crashes when resetting a database with at least one entry having core seconds equal to `None`.