### PR TITLE
setup.py add install_requires

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -54,7 +54,7 @@ setup(name='sams-software-accounting',
       packages=['sams','sams.aggregator','sams.loader','sams.output','sams.pidfinder','sams.sampler',
                 'sams.backend','sams.software','sams.xmlwriter'],
       scripts = ['sams-aggregator.py','sams-collector.py','sams-post-receiver.py',
-                 'sams-post-receiver.py','sams-software-extractor.py','sams-software-updater.py',
+                 'sams-software-extractor.py','sams-software-updater.py',
                  'extras/sgas-sa-registrant/bin/sgas-sa-registrant'],
       install_requires = [
           'Flask',

--- a/setup.py
+++ b/setup.py
@@ -2,6 +2,7 @@ import os
 from distutils.core import setup
 from distutils.command.install import install
 from distutils.command.install_data import install_data
+import setuptools
 
 from sams import __version__
 

--- a/setup.py
+++ b/setup.py
@@ -55,6 +55,12 @@ setup(name='sams-software-accounting',
       scripts = ['sams-aggregator.py','sams-collector.py','sams-post-receiver.py',
                  'sams-post-receiver.py','sams-software-extractor.py','sams-software-updater.py',
                  'extras/sgas-sa-registrant/bin/sgas-sa-registrant'],
+      install_requires = [
+          'Flask',
+          'httplib2',
+          'Twisted',
+          'PyYAML',
+      ],
       cmdclass = cmdclasses,
 
       data_files = [


### PR DESCRIPTION
Specify requirements for setuptool, and a tiny bugfix.

I am not 100% up to date with best practices for Python packaging, but this appears to work for my use case. I build a source package using `python3 setup.py sdist`, then build RPM packages from that. The automatic dependency generator macro in modern RPM dists picks up these depencencies. I did not get this to work without the setuptools import.