### PR TITLE
Slurminfo fallback

### DIFF
--- a/docs/loader/FileSlurmInfoFallback.md
+++ b/docs/loader/FileSlurmInfoFallback.md
@@ -4,6 +4,9 @@ Extends sams.loader.File but will use sacct to fetch data
 from slurmdbd if sams.sampler.SlurmInfo is not used or 
 failes to fetch data.
 
+A modified file that includes the fetched SlurmInfo is stored in
+archive_path. The original input file is removed.
+
 Used by the [*sams-aggregator*](../sams-aggregator.md)
 
 # Config options

--- a/docs/loader/FileSlurmInfoFallback.md
+++ b/docs/loader/FileSlurmInfoFallback.md
@@ -35,5 +35,5 @@ sams.loader.FileSlurmInfoFallback:
   file_pattern: '^.*\.json$'
   sacct: /usr/bin/sacct
   environment:
-    TZ=UTC
+    TZ: UTC
 ```

--- a/sams-aggregator.py
+++ b/sams-aggregator.py
@@ -129,6 +129,7 @@ class Main:
                     if not data:
                         break
                 except Exception as e:
+                    logger.error(e)
                     l.error()
                     continue
 

--- a/sams/loader/FileSlurmInfoFallback.py
+++ b/sams/loader/FileSlurmInfoFallback.py
@@ -73,6 +73,8 @@ class Loader(File):
 
     def next(self):
         data = super(Loader, self).next()
+        if data is None:
+            return None
         if not data.get("sams.sampler.SlurmInfo", {}):
             jobid = int(data["sams.sampler.Core"]["jobid"])
             sacct = SacctLoader(self.sacct, self.env)

--- a/sams/loader/FileSlurmInfoFallback.py
+++ b/sams/loader/FileSlurmInfoFallback.py
@@ -45,31 +45,35 @@ class SacctLoader:
                 "-X",
                 "-n",
                 "-o",
-                "Account,Start,User,NNodes,NCPU,Partition,UID",
+                "JobIDRaw,Account,Start,User,NNodes,NCPU,Partition,UID",
             ],
             check=True,
             env=self.env,
             encoding="utf8",
             stdout=subprocess.PIPE,
         )
-        (
-            account,
-            starttime,
-            username,
-            nodes,
-            cpus,
-            partition,
-            uid,
-        ) = process.stdout.strip().split("|")
-        return dict(
-            account=account,
-            starttime=starttime,
-            username=username,
-            nodes=nodes,
-            cpus=cpus,
-            partition=partition,
-            uid=uid,
-        )
+        for line in process.stdout.splitlines():
+            (
+                jobidraw,
+                account,
+                starttime,
+                username,
+                nodes,
+                cpus,
+                partition,
+                uid,
+            ) = line.strip().split("|")
+            if int(jobidraw) == jobid:
+                return dict(
+                    account=account,
+                    starttime=starttime,
+                    username=username,
+                    nodes=nodes,
+                    cpus=cpus,
+                    partition=partition,
+                    uid=uid,
+                )
+        raise Exception(f"jobid {jobid} not found in sacct output")
 
 
 class Loader(File):

--- a/sams/loader/FileSlurmInfoFallback.py
+++ b/sams/loader/FileSlurmInfoFallback.py
@@ -37,7 +37,7 @@ class SacctLoader:
         for k, v in self.env.items():
             local_env[k] = v
 
-        process = subprocess.Popen(
+        process = subprocess.run(
             [
                 self.sacct,
                 "-P",
@@ -48,12 +48,20 @@ class SacctLoader:
                 "-o",
                 "Account,Start,User,NNodes,NCPU,Partition,UID",
             ],
+            check=True,
             env=local_env,
+            encoding="utf8",
             stdout=subprocess.PIPE,
         )
-        (account, starttime, username, nodes, cpus, partition, uid) = (
-            process.stdout.readline().decode("ascii").strip().split("|")
-        )
+        (
+            account,
+            starttime,
+            username,
+            nodes,
+            cpus,
+            partition,
+            uid,
+        ) = process.stdout.strip().split("|")
         return dict(
             account=account,
             starttime=starttime,

--- a/sams/loader/FileSlurmInfoFallback.py
+++ b/sams/loader/FileSlurmInfoFallback.py
@@ -44,7 +44,7 @@ class SacctLoader:
                 "-j",
                 str(jobid),
                 "-X",
-                "--noheader",
+                "-n",
                 "-o",
                 "Account,Start,User,NNodes,NCPU,Partition,UID",
             ],


### PR DESCRIPTION
Various fixes and improvements to sams.loader.FileSlurmInfoFallback:

* Fix `environment` in documentation example
* Avoid Exceptions when reaching the last input record
* Change `subprocess.Popen` to `subprocess.run` and only create `SacctLoader` once
* Support array jobs
* Save the generated SlurmInfo in the archived json file
* Better logging in sams-aggregator - was used to debug the above

Changes are still not fully tested, marking this as Draft.