### PR TITLE
Get JobName in SlurmInfo sampler

### DIFF
--- a/sams/sampler/SlurmInfo.py
+++ b/sams/sampler/SlurmInfo.py
@@ -122,6 +122,11 @@ class Sampler(sams.base.Sampler):
         if starttime:
             self.data["starttime"] = starttime.group(1)
 
+        # Find JobName
+        jobname = re.search(r"JobName=([^ ]+)", data)
+        if jobname:
+            self.data["jobname"] = jobname.group(1)
+
         if not self.do_sample():
             self.store(self.data)
 


### PR DESCRIPTION
This is a previous update authored by @apolloford that we have implemeted at c3se. In brief, it lets `SlurmInfo` push a `"jobname"` entry.