### PR TITLE
Add sampler.most_recent_sample property

### DIFF
--- a/sams/base.py
+++ b/sams/base.py
@@ -51,6 +51,7 @@ class Sampler(threading.Thread):
     def __init__(self, id, outQueue, config):
         super(Sampler, self).__init__()
         self.id = id
+        self._most_recent_sample = None
         self.outQueue = outQueue
         self.config = config
         self.jobid = self.config.get(["options", "jobid"])
@@ -89,8 +90,21 @@ class Sampler(threading.Thread):
             logger.exception("Failed to do self.final_data in %s", self.id)
         self.outQueue.join()
 
+    def _storage_wrapping(self, data, type="now"):
+        """
+        Convenience method for wrapping data into a dictionary used
+        by several other methods.
+        """
+        return {"id": self.id, "data": data, "type": type} 
+
     def store(self, data, type="now"):
-        self.outQueue.put({"id": self.id, "data": data, "type": type})
+        self.outQueue.put(self._storage_wrapping(data, type))
+
+    @property
+    def most_recent_sample(self):
+        """ The most recently sample or set of samples stored by a call
+        to ``self.sample()``."""
+        return self._most_recent_sample
 
     # this should be implemented in the real Sampler..
     # pylint: disable=no-self-use

--- a/sams/sampler/Core.py
+++ b/sams/sampler/Core.py
@@ -48,6 +48,7 @@ class Sampler(sams.base.Sampler):
             "jobid": self.config.get(["options", "jobid"]),
             "node": self.config.get(["options", "node"]),
         }
+        self._most_recent_sample = self._storage_wrapping(self.core)
         self.store(self.core)
 
     def do_sample(self):

--- a/sams/sampler/FSStats.py
+++ b/sams/sampler/FSStats.py
@@ -97,7 +97,10 @@ class Sampler(sams.base.Sampler):
     def sample(self):
         logger.debug("sample()")
         if self.fsstat:
-            self.store(self.fsstat.sample())
+            fsstat_sample = self.fsstat.sample()
+            self._most_recent_sample = self._sample_wrapping(fsstat_sample)
+            self.store(fsstat_sample)
+
 
     @classmethod
     def final_data(cls):

--- a/sams/sampler/IOStats.py
+++ b/sams/sampler/IOStats.py
@@ -156,6 +156,7 @@ class Sampler(sams.base.Sampler):
         while not self.job_iostat.queue.empty():
             data = self.job_iostat.queue.get()
             logger.debug(data)
+            self._most_recent_sample = self._storage_wrapping(data)
             self.store(data)
 
     def final_data(self):

--- a/sams/sampler/NvidiaSMI.py
+++ b/sams/sampler/NvidiaSMI.py
@@ -166,12 +166,15 @@ class Sampler(sams.base.Sampler):
 
     def sample(self):
         logger.debug("sample()")
+        self._most_recent_sample = []
         while not self.smi.queue.empty():
             data = self.smi.queue.get()
             logger.debug(data)
             index = data["index"]
             del data["index"]
-            self.store({index: data})
+            entry = {index: data}
+            self._most_recent_sample.append(self._storage_wrapping(entry))
+            self.store(entry)
 
     def final_data(self):
         if self.smi:

--- a/sams/sampler/SlurmCGroup.py
+++ b/sams/sampler/SlurmCGroup.py
@@ -66,15 +66,15 @@ class Sampler(sams.base.Sampler):
             "memory", "memory.memsw.usage_in_bytes"
         )
 
-        self.store(
-            {
-                "cpus": cpus,
-                "memory_usage": memory_usage,
-                "memory_limit": memory_limit,
-                "memory_max_usage": memory_max_usage,
-                "memory_swap": str(int(memory_usage_and_swap) - int(memory_usage)),
-            }
-        )
+        entry = {
+            "cpus": cpus,
+            "memory_usage": memory_usage,
+            "memory_limit": memory_limit,
+            "memory_max_usage": memory_max_usage,
+            "memory_swap": str(int(memory_usage_and_swap) - int(memory_usage)),
+        }
+        self._most_recent_sample = self._storage_wrapping(entry)
+        self.store(entry)
 
     def _get_cgroup(self):
         """ Get the cgroup base path for the slurm job """

--- a/sams/sampler/SlurmInfo.py
+++ b/sams/sampler/SlurmInfo.py
@@ -122,6 +122,11 @@ class Sampler(sams.base.Sampler):
         if starttime:
             self.data["starttime"] = starttime.group(1)
 
+        # Find JobName
+        jobname = re.search(r"JobName=([^ ]+)", data)
+        if jobname:
+            self.data["jobname"] = jobname.group(1)
+
         if not self.do_sample():
             self.store(self.data)
 

--- a/sams/sampler/SlurmInfo.py
+++ b/sams/sampler/SlurmInfo.py
@@ -128,6 +128,7 @@ class Sampler(sams.base.Sampler):
             self.data["jobname"] = jobname.group(1)
 
         if not self.do_sample():
+            self._most_recent_sample = self._storage_wrapping(self.data)
             self.store(self.data)
 
     def final_data(self):

--- a/sams/sampler/Software.py
+++ b/sams/sampler/Software.py
@@ -205,19 +205,19 @@ class Sampler(sams.base.Sampler):
         if self.last_sample_time:
             time_diff = time.time() - self.last_sample_time
             if time_diff > self.sampler_interval / 2:
-                self.store(
-                    {
-                        "current": {
-                            "software": self.map_software(aggr),
-                            "total_user": total["user"],
-                            "total_system": total["system"],
-                            "user": (total["user"] - self.last_total["user"])
-                            / time_diff,
-                            "system": (total["system"] - self.last_total["system"])
-                            / time_diff,
+                entry = {
+                    "current": {
+                        "software": self.map_software(aggr),
+                        "total_user": total["user"],
+                        "total_system": total["system"],
+                        "user": (total["user"] - self.last_total["user"])
+                        / time_diff,
+                        "system": (total["system"] - self.last_total["system"])
+                        / time_diff,
                         }
                     }
-                )
+                self._most_recent_sample = self._storage_wrapping(entry)
+                self.store(entry)
                 self.last_total = total
                 self.last_sample_time = time.time()
         else:

--- a/sams/sampler/ZFSStats.py
+++ b/sams/sampler/ZFSStats.py
@@ -97,7 +97,9 @@ class Sampler(sams.base.Sampler):
     def sample(self):
         logger.debug("sample()")
         if self.zfsstat:
-            self.store(self.zfsstat.sample())
+            entry = self._zfsstat.sample()
+            self._most_recent_sample = self._storage_wrapping(entry)
+            self.store(entry)
 
     @classmethod
     def final_data(cls):


### PR DESCRIPTION
This PR implements a `most_recent_sample` property of the `Sampler` class, which fetches the most recent sample or set of samples stored, wrapping them in the same dictionary structure as is done by self.store, which is done through a common utility function.

The goal of this is to enably asynchronous, on-demand fetching of the most recent sample for each job by a service running on the node.

Some discussion could be had about whether one should store the most recent sample as a list with one entry or not, since in the case of `NvidiaSMI` it is necessary to make a list to include multiple GPUs, possible repeated sampling due to the asynchronous running of `nvidia-smi` etc. Currently I have chosen not to enforce `most_recent_sample` being a list (which may require some annoying checks, such as whether it has the attribute `'keys'`), but this can easily be changed.