### PR TITLE
Add "StartTimeStamp" output in SlurmInfo

### DIFF
--- a/sams/sampler/SlurmInfo.py
+++ b/sams/sampler/SlurmInfo.py
@@ -41,6 +41,7 @@ Output:
     uid: 65535,
 }
 """
+import datetime
 import logging
 import os
 import re
@@ -121,6 +122,9 @@ class Sampler(sams.base.Sampler):
         starttime = re.search(r"StartTime=(\d\d\d\d-\d\d-\d\dT\d\d:\d\d:\d\d)", data)
         if starttime:
             self.data["starttime"] = starttime.group(1)
+            starttimestamp = datetime.datetime(
+                    *[int(i) for i in re.findall(r'\d+', starttime.group(1))]).timestamp()
+            self.data["starttimestamp"] = starttimestamp
 
         # Find JobName
         jobname = re.search(r"JobName=([^ ]+)", data)


### PR DESCRIPTION
It is desireable for some purposes to have access to the exact, persistent timestamp that a job started on a machine which may not have access to Slurm or be aware of timezones, datetimeformats, and other configurable factors. The easiest way to achieve this is to simply compute the timestamp directly from "starttime" as this is fetched from scontrol show in SlurmInfo. This PR accomplishes this by adding the entry "starttimestamp".

(This is a feature we have been using for a while, it is important to some time-sensitive things like killing jobs, but I noticed that I hadn't pushed it upstream now when I added some new features.)