### PR TITLE
Implement averaging functionality in SlurmCGroup2

### DIFF
--- a/sams/sampler/SlurmCGroup2.py
+++ b/sams/sampler/SlurmCGroup2.py
@@ -44,7 +44,7 @@ class Sampler(BaseCGroupSampler):
             "memory_limit": memory_limit,
             "memory_max_usage": memory_max_usage,
             "memory_swap": str(int(memory_usage_and_swap) - int(memory_usage))}
-
+        self.compute_sample_averages(entry)
         self._most_recent_sample = [self._storage_wrapping(entry)]
         self.store(entry)
 


### PR DESCRIPTION
Because I made #37 and #39 in parallel, the calling of the sample averaging function was not implemented in SlurmCGroup2, and any average metrics will therefore be ignored. This is a single-line commit to insert the missing call.